### PR TITLE
add variabels for 3ds & otp verifications

### DIFF
--- a/LiqPay.php
+++ b/LiqPay.php
@@ -22,6 +22,7 @@ class LiqPay extends Component
     public $language = 'ru';
     public $server_url;
     public $result_url;
+    public $paymentName;
 
     /**
      * @inheritdoc

--- a/forms/CallbackForm.php
+++ b/forms/CallbackForm.php
@@ -48,6 +48,9 @@ class CallbackForm extends Model
     public $status;
     public $card_token;
 
+    public $token;
+    public $redirect_to;
+
     /**
      * @return string
      */
@@ -70,6 +73,7 @@ class CallbackForm extends Model
             ['currency', 'in', 'range' => array_keys(self::getCurrencyItems())],
             ['type', 'in', 'range' => array_keys(self::getTypeItems())],
             ['status', 'in', 'range' => array_keys(self::getStatusItems())],
+            [['token','redirect_to'], 'safe']
         ];
     }
 


### PR DESCRIPTION
api can return the payment statuses "otp_verify" and "3ds_verify" with them come the parameters of "token" and "redirect_url" I added properties to the method to be able to work with them in CallbackForm
